### PR TITLE
Override text index options

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,7 +125,7 @@ function fuzzySearch(...args) {
  * @param {object} schema - Mongo Collection
  * @param {object} options - plugin options
  */
-module.exports = function (schema, pluginOptions) {
+module.exports = function (schema, pluginOptions, indexOverrideOptions = {}) {
   if (!pluginOptions || (pluginOptions && !pluginOptions.fields)) {
     throw new Error('You must set at least one field for fuzzy search.');
   }
@@ -140,7 +140,7 @@ module.exports = function (schema, pluginOptions) {
   validateMiddlewares(middlewares);
 
   const { indexes, weights } = createFields(schema, fields);
-  schema.index(indexes, { weights, name: 'fuzzy_text' });
+  schema.index(indexes, { ...indexOverrideOptions, weights, name: 'fuzzy_text' });
 
   const hideElements = removeFuzzyElements(fields);
   const { toJSON, toObject } = setTransformers(hideElements)(schema);

--- a/index.js
+++ b/index.js
@@ -125,12 +125,13 @@ function fuzzySearch(...args) {
  * @param {object} schema - Mongo Collection
  * @param {object} options - plugin options
  */
-module.exports = function (schema, pluginOptions, indexOverrideOptions = {}) {
+module.exports = function (schema, pluginOptions) {
   if (!pluginOptions || (pluginOptions && !pluginOptions.fields)) {
     throw new Error('You must set at least one field for fuzzy search.');
   }
 
   const { fields, middlewares } = pluginOptions;
+  const indexOverrideOptions = pluginOptions || {};
 
   if (!Array.isArray(fields)) {
     throw new TypeError('Fields must be an array.');

--- a/index.js
+++ b/index.js
@@ -131,7 +131,7 @@ module.exports = function (schema, pluginOptions) {
   }
 
   const { fields, middlewares } = pluginOptions;
-  const indexOverrideOptions = pluginOptions || {};
+  const indexOverrideOptions = pluginOptions.indexOverrideOptions || {};
 
   if (!Array.isArray(fields)) {
     throw new TypeError('Fields must be an array.');


### PR DESCRIPTION
## Description

To be able to work, this plugin creates a text index in the collection where fuzzy search is needed, the plugin only sets some properties when creating the index, so the index uses some of the default values. One of these properties is the language override, this lets you specify the name of the field that contains the language of the document. The default is the field  `language`. This presented an issue with a collection that already had that field, but the values are not compatible with mongoDB; mongo expects the language itself such as `english` or `spanish` while we have the ISO codes such as `en` or `en-US`

Since this plugin seems to no longer be maintained (2 years since last commit) I had to fork the original repo to add the fix (I will report this issue anyway).

To fix is this, the plugin function was modified, so it would accept `indexOverrideOptions` that is an object that will accept these changes such as the language default field.

This may be improved by validating each property in this object, but since this use case only applies to one of our collections, I don't think it's necessary yet.

You can check mongoDB documentation on text index for more [information](https://www.mongodb.com/docs/manual/core/index-text/)

I will leave a picture of how the change is reflected in the DB for better understanding
![Screen Shot 2022-10-06 at 14 57 23](https://user-images.githubusercontent.com/7119875/194406993-ffae0421-4a90-4f32-8a2e-e4b3fd057b50.png)


